### PR TITLE
docs: document task lookup APIs

### DIFF
--- a/src/api-reference.md
+++ b/src/api-reference.md
@@ -55,6 +55,39 @@ const task = cron.createTask('0 * * * *', () => {
 task.start();
 ```
 
+## 🔹 `getTasks(): Map<string, ScheduledTask>`
+
+Returns all tasks currently registered by node-cron, keyed by task id. Tasks created with `schedule` or `createTask` are registered automatically, and destroyed tasks are removed from the registry.
+
+```ts
+import cron from 'node-cron';
+
+const task = cron.schedule('* * * * *', () => {
+  console.log('Running every minute');
+});
+
+const tasks = cron.getTasks();
+
+console.log(tasks.has(task.id)); // true
+console.log(tasks.get(task.id) === task); // true
+```
+
+## 🔹 `getTask(taskId: string): ScheduledTask | undefined`
+
+Returns a registered task by id, or `undefined` when no task exists for that id.
+
+```ts
+import cron from 'node-cron';
+
+const task = cron.schedule('* * * * *', () => {
+  console.log('Running every minute');
+});
+
+const sameTask = cron.getTask(task.id);
+
+sameTask?.stop();
+```
+
 ## 🔹 `validate(expression: string): boolean`
 
 Validates whether a given cron expression is syntactically correct.


### PR DESCRIPTION
Documents the task lookup APIs requested in node-cron/node-cron#469.

Changes:
- Adds `cron.getTasks(): Map<string, ScheduledTask>` to the API reference.
- Adds `cron.getTask(taskId: string): ScheduledTask | undefined` to the API reference.
- Includes small usage examples based on `task.id`.

Validation:
- `npm run build`
- `git diff --check`

Note: `npm ci` timed out after 120 seconds in this environment, but dependencies installed far enough for the VitePress docs build to pass. `package-lock.json` is unchanged.