### PR TITLE
docs: fix background task context example

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -55,7 +55,7 @@ cron.schedule('* * * * *', async (ctx) => {
   console.log(`Task started at ${ctx.triggeredAt.toISOString()}`);
   console.log(`Scheduled for: ${ctx.dateLocalIso}`);
 
-  cosole.log(`Task status ${ctx.task.getStatus()}`)
+  console.log(`Task status ${ctx.task.getStatus()}`)
 });
 ```
 
@@ -63,10 +63,10 @@ The same may be done with background tasks:
 
 ```js
 // ./tasks/my-task.js
-export function task() => {
+export function task(ctx) {
   console.log(`Task started at ${ctx.triggeredAt.toISOString()}`);
   console.log(`Scheduled for: ${ctx.dateLocalIso}`);
-  cosole.log(`Task status ${ctx.task.getStatus()}`)
+  console.log(`Task status ${ctx.task.getStatus()}`)
 };
 
 ```


### PR DESCRIPTION
Closes #8.

Summary:
- Updates the background task context example to declare the `ctx` parameter it uses.
- Fixes the nearby `console.log` typos in the inline and background task examples.

Checks:
- `npm run build`
- `git diff --check HEAD~1 HEAD`

AI assistance disclosure:
- OpenAI Codex assisted with this change; the commit includes `Co-authored-by: OpenAI Codex <codex@openai.com>`.