### PR TITLE
docs: add Logging page (setLogger + suppressing missed-execution warning)

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -36,6 +36,7 @@ export default {
           { text: 'Scheduling Options', link: '/scheduling-options' },
           { text: 'Task Controls', link: '/task-controls' },
           { text: 'Event Listening', link: '/event-listening' },
+          { text: 'Logging', link: '/logging' },
           { text: 'Background Tasks', link: '/background-tasks' },
           { text: 'Migrationg from V3', link: '/migrating-from-v3' },
          

--- a/src/api-reference.md
+++ b/src/api-reference.md
@@ -16,9 +16,11 @@ Schedules a task to be executed based on a cron expression.
 ```ts
 type Options = {
   name?: string;
-  timezone?: string;       // E.g., "America/New_York"
-  noOverlap?: boolean;     // Prevents overlapping executions
-  maxExecutions?: number;  // Maximum number of times the task should run
+  timezone?: string;              // E.g., "America/New_York"
+  noOverlap?: boolean;            // Prevents overlapping executions
+  maxExecutions?: number;         // Maximum number of times the task should run
+  logger?: Logger;                // Per-task logger (see Logging)
+  suppressMissedWarning?: boolean // Silence the "missed execution" warning
 };
 ```
 
@@ -67,3 +69,23 @@ cron.validate('invalid');    // false
 ```
 
 Returns true if the expression is valid, false otherwise.
+
+## 🔹 `setLogger(logger)`
+
+Replaces the global logger used by node-cron, letting you route internal
+messages (such as the missed-execution warning) through your own logger.
+
+```ts
+import { setLogger } from 'node-cron';
+
+setLogger({
+  info:  (msg) => {},
+  warn:  (msg) => myLogger.warn(msg),
+  error: (msg) => myLogger.error(msg),
+  debug: (msg) => {},
+});
+```
+
+The logger is any object implementing the `Logger` interface (`info`, `warn`,
+`error`, `debug`). See the [Logging guide](/logging) for details, per-task
+loggers, and suppressing the missed-execution warning.

--- a/src/logging.md
+++ b/src/logging.md
@@ -1,0 +1,129 @@
+# Logging
+
+node-cron writes a few internal messages — most notably a warning when a
+scheduled execution is missed (usually caused by blocking I/O or high CPU in
+the same process). You can route these messages through your own logger and
+control the missed-execution warning.
+
+## The `Logger` interface
+
+A logger is any object that implements these four methods. You don't need to
+extend or `implements` anything — any matching object works (structural typing).
+
+```ts
+interface Logger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string | Error, err?: Error): void;
+  debug(message: string | Error, err?: Error): void;
+}
+```
+
+> 🛈 `error` and `debug` may receive either a `string` or an `Error`, so handle
+> both in your adapter.
+
+## Setting a global logger
+
+Use `setLogger` to replace the built-in console logger for the whole module:
+
+```js
+import cron, { setLogger } from 'node-cron';
+
+setLogger({
+  info:  (msg) => myLogger.info(msg),
+  warn:  (msg) => myLogger.warn(msg),
+  error: (msg) => myLogger.error(msg),
+  debug: (msg) => myLogger.debug(msg),
+});
+```
+
+In CommonJS:
+
+```js
+const cron = require('node-cron');
+cron.setLogger({ /* ... */ });
+```
+
+### Using winston / pino
+
+Both expose `info`/`warn`/`error`/`debug`, so they are almost a drop-in:
+
+```js
+import pino from 'pino';
+import { setLogger } from 'node-cron';
+
+const log = pino();
+
+setLogger({
+  info:  (m) => log.info(m),
+  warn:  (m) => log.warn(m),
+  error: (m, e) => log.error(e ?? m),
+  debug: (m) => log.debug(m),
+});
+```
+
+### Silencing all output
+
+Pass a logger whose methods do nothing:
+
+```js
+const noop = () => {};
+setLogger({ info: noop, warn: noop, error: noop, debug: noop });
+```
+
+## Per-task logger
+
+You can also override the logger for a single task with the `logger` option. It
+takes precedence over the global logger for that task:
+
+```js
+const task = cron.schedule('* * * * *', () => {}, {
+  logger: myTaskLogger,
+});
+```
+
+> 🛈 The per-task `logger` is **not** supported for [Background Tasks](/background-tasks),
+> because it cannot cross the worker process boundary. For background tasks, use
+> the global `setLogger` (the parent process does the logging from the worker's
+> events) or call `setLogger` inside the task file itself.
+
+## Suppressing the "missed execution" warning
+
+When a scheduled execution is missed, node-cron logs:
+
+```
+[NODE-CRON] [WARN] missed execution at <time>! Possible blocking IO or high CPU ...
+```
+
+This warning is intentional — it surfaces environments where blocking I/O or CPU
+pressure is causing node-cron to miss runs. It is suppressed automatically when
+you take ownership of the signal, in either of two ways:
+
+### 1. Listen to the `execution:missed` event
+
+If a listener is attached, node-cron assumes you are handling it and stays quiet:
+
+```js
+const task = cron.schedule('* * * * *', () => {});
+
+task.on('execution:missed', (ctx) => {
+  // you decide what to do — log it, alert, ignore, etc.
+  metrics.increment('cron.missed', { date: ctx.date });
+});
+```
+
+See [Event Listening](/event-listening) for the full event list and payload.
+
+### 2. Opt out explicitly with `suppressMissedWarning`
+
+If you simply want the warning off (without listening), set the option:
+
+```js
+const task = cron.schedule('* * * * *', () => {}, {
+  suppressMissedWarning: true,
+});
+```
+
+> ⚠️ Suppressing the warning hides a real signal: your task may be missing
+> executions due to blocking I/O or high CPU. Prefer fixing the root cause, or
+> running the job as a [Background Task](/background-tasks), before silencing it.

--- a/src/scheduling-options.md
+++ b/src/scheduling-options.md
@@ -11,6 +11,8 @@ export type Options = {
   noOverlap?: boolean;
   maxExecutions?: number;
   maxRandomDelay?: number;
+  logger?: Logger;
+  suppressMissedWarning?: boolean;
 };
 ```
 
@@ -23,6 +25,8 @@ export type Options = {
 | `noOverlap`      | `boolean` | If `true`, prevents overlapping runs. If a task is still executing when the next scheduled time arrives, the new run is skipped. Defaults to `false`|
 | `maxExecutions`  | `number`  | Sets a limit on how many times the task should execute. After reaching this count, the task is automatically destroyed. |
 | `maxRandomDelay` | `number`  | (Jitter) Adds up to the specified number of milliseconds of random delay before executing each scheduled run. Useful to prevent “thundering herd” effects when many tasks are scheduled at the same time. Default is 0 (no delay). |
+| `logger`         | `Logger`  | A custom logger for this task, overriding the global one. See [Logging](/logging). Not supported for background tasks. |
+| `suppressMissedWarning` | `boolean` | If `true`, suppresses the "missed execution" warning for this task. See [Logging](/logging). Defaults to `false`. |
 
 > 🛈 Unlike older versions, `scheduled` and `runOnInit` are no longer used. By default, tasks are scheduled and started immediately upon creation. If you need a task that is initially stopped, use the `createTask` function. To manually run a task immediately after scheduling, simply call `task.execute()` after the task has been scheduled.
 


### PR DESCRIPTION
Documents the configurable logger and the missed-execution warning controls.

## Changes
- **New page `Logging`** (`src/logging.md`):
  - The `Logger` interface (structural typing — no `implements` needed).
  - `setLogger` for a global logger, plus winston/pino adapters and how to silence all output.
  - Per-task `logger` option, with the note that it does not apply to background tasks (it can't cross the worker boundary).
  - Suppressing the "missed execution" warning two ways: listening to `execution:missed`, or `suppressMissedWarning: true` — with a caution that it hides a real signal.
- **Scheduling Options**: added `logger` and `suppressMissedWarning` to the type and field table.
- **Node-Cron Module**: added a `setLogger(logger)` entry and the new options.
- **Sidebar**: added "Logging".

`vitepress build` passes (no broken links).

## Note
This documents the configurable-logger feature from node-cron PR #524, which is not yet released. Hold the publish/deploy until that ships in a node-cron release, otherwise it documents an API not present in the current npm version (4.2.1).