### PR TITLE
fix: serve clean URLs by rewriting extensionless paths to .html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run docs:build",
   "outputDirectory": "dist",
-  "framework": null
+  "framework": null,
+  "rewrites": [
+    { "source": "/:path((?!.*\\.).*)", "destination": "/:path.html" }
+  ]
 }


### PR DESCRIPTION
Direct hits on extensionless page URLs (e.g. `/getting-started`) returned 404 in production, because VitePress builds `.html` files and Vercel did not resolve the clean path. Only `*.html` worked.

This adds a Vercel rewrite mapping dot-less paths to their `.html` file. Rewrites run **after** the filesystem check, so existing files (`llms.txt`, `*.md`, `*.html`, `sitemap.xml`, assets) are served directly and `.html` stays canonical; only the previously-404ing clean routes are rewritten, with no redirect (least disruptive for existing SEO).

Verify on the Vercel preview: `/getting-started` should now return 200, while `/getting-started.html`, `/llms.txt`, and `/getting-started.md` keep working.