### PR TITLE
docs: distributed coordination, task introspection, and parse/validateDetailed

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
         items: [
           { text: 'Events & Observability', link: '/event-listening' },
           { text: 'Background Tasks', link: '/background-tasks' },
+          { text: 'Distributed Coordination', link: '/distributed-coordination' },
           { text: 'Logging', link: '/logging' },
         ]
       },

--- a/src/api-reference.md
+++ b/src/api-reference.md
@@ -13,9 +13,12 @@ import cron, {
   schedule,
   createTask,
   validate,
+  validateDetailed,
+  parse,
   getTasks,
   getTask,
   setLogger,
+  setRunCoordinator,
 } from 'node-cron';
 ```
 
@@ -45,6 +48,9 @@ type Options = {
   logger?: Logger;                // per-task logger (not for background tasks)
   suppressMissedWarning?: boolean // silence the "missed execution" warning
   missedExecutionTolerance?: number // ms a late run may still execute (default 1000)
+  distributed?: boolean;          // run on one instance per fire across a fleet
+  runCoordinator?: RunCoordinator;// per-task coordinator (overrides the global one)
+  distributedTtl?: number;        // lease ms for lease-based coordinators (default 30000)
 };
 ```
 
@@ -94,6 +100,63 @@ import cron from 'node-cron';
 cron.validate('0 12 * * *'); // true
 cron.validate('invalid');    // false
 ```
+
+## `validateDetailed(expression)`
+
+Like `validate`, but instead of a boolean returns a structured result describing **every** problem (which field, the offending value, and why). Useful for tooling, editors, and richer error messages.
+
+```ts
+type CronFieldError = { field: string; value?: string; message: string };
+type DetailedValidation = {
+  valid: boolean;
+  fields?: ParsedFields;   // present only when valid
+  errors: CronFieldError[];
+};
+```
+
+```js
+import { validateDetailed } from 'node-cron';
+
+validateDetailed('0 12 * * *');
+// { valid: true, errors: [], fields: { second: [0], minute: [0], hour: [12], ... } }
+
+validateDetailed('99 12 * * 9');
+// {
+//   valid: false,
+//   errors: [
+//     { field: 'minute',    value: '99', message: '99 is a invalid expression for minute' },
+//     { field: 'dayOfWeek', value: '9',  message: '9 is a invalid expression for week day' },
+//   ]
+// }
+```
+
+It reports **every** bad field at once (not just the first). See [Cron Syntax](/cron-syntax#validating-expressions).
+
+## `parse(expression)`
+
+Parses a cron expression into its decomposed, expanded fields, or **throws** an `Error` describing the first invalid field.
+
+```ts
+type ParsedFields = {
+  second: number[];
+  minute: number[];
+  hour: number[];
+  dayOfMonth: (number | string)[];
+  month: number[];
+  dayOfWeek: number[];
+};
+```
+
+```js
+import { parse } from 'node-cron';
+
+parse('0 12 * * 1-5');
+// { second: [0], minute: [0], hour: [12], dayOfMonth: [1, …, 31], month: [1, …, 12], dayOfWeek: [1, 2, 3, 4, 5] }
+
+parse('0 99 * * *'); // throws: 99 is a invalid expression for hour
+```
+
+Use `parse` when you want the structured fields (or a thrown error); use [`validate`](#validate-expression) for a boolean and [`validateDetailed`](#validatedetailed-expression) for a non-throwing list of problems.
 
 ## `getTasks()`
 
@@ -151,6 +214,28 @@ setLogger({
 ```
 
 The argument is any object implementing the `Logger` interface (`info`, `warn`, `error`, `debug`). See the [Logging guide](/logging) for the full interface, per-task loggers, winston/pino adapters, and the missed-execution warning.
+
+## `setRunCoordinator(coordinator)`
+
+Sets the process-wide [run coordinator](/distributed-coordination) used by tasks scheduled with `distributed: true`. This is the high-availability path: any instance can run a fire, only one wins. Without it, `distributed` tasks fall back to the `NODE_CRON_RUN` env-var default (a single designated runner).
+
+```js
+import { setRunCoordinator } from 'node-cron';
+import { RedisLockCoordinator } from '@node-cron/redis-coordinator';
+
+setRunCoordinator(new RedisLockCoordinator(redis));
+```
+
+The argument is any object implementing the `RunCoordinator` interface:
+
+```ts
+interface RunCoordinator {
+  shouldRun(key: string, ttlMs: number): boolean | Promise<boolean>;
+  onComplete?(key: string): void | Promise<void>;
+}
+```
+
+Pass `undefined` to clear it. A per-task coordinator can be set via the [`runCoordinator`](/scheduling-options) option. See [Distributed Coordination](/distributed-coordination) for the full guide.
 
 ## Next steps
 

--- a/src/background-tasks.md
+++ b/src/background-tasks.md
@@ -125,4 +125,5 @@ When a background task starts, node-cron forks a process and launches a small **
 ## Next steps
 
 - **[Logging](/logging)**: essential for background tasks, since logging happens in the parent.
+- [Distributed Coordination](/distributed-coordination): run a background task on one instance per fire across a fleet.
 - [Cookbook](/cookbook): practical recipes, including a backup job.

--- a/src/cron-syntax.md
+++ b/src/cron-syntax.md
@@ -159,7 +159,19 @@ cron.validate('0 12 * * *'); // true
 cron.validate('not a cron'); // false
 ```
 
-See [`validate`](/api-reference#validate-expression) in the API reference.
+For tooling and richer error messages, two more helpers go beyond a boolean:
+
+- [`validateDetailed(expr)`](/api-reference#validatedetailed-expression) returns **every** problem (which field, value, and why) without throwing.
+- [`parse(expr)`](/api-reference#parse-expression) returns the decomposed fields, or throws on the first invalid one.
+
+```js
+import { validateDetailed } from 'node-cron';
+
+validateDetailed('99 12 * * 9').errors;
+// [ { field: 'minute', value: '99', ... }, { field: 'dayOfWeek', value: '9', ... } ]
+```
+
+See [`validate`](/api-reference#validate-expression), [`validateDetailed`](/api-reference#validatedetailed-expression), and [`parse`](/api-reference#parse-expression) in the API reference.
 
 ## Next steps
 

--- a/src/distributed-coordination.md
+++ b/src/distributed-coordination.md
@@ -1,0 +1,174 @@
+---
+outline: deep
+title: Distributed Coordination
+description: Run a node-cron task on a single instance per fire across a fleet of replicas. Covers the distributed option, the NODE_CRON_RUN env-var default, custom RunCoordinators (e.g. Redis) for HA, and the execution:skipped event.
+---
+
+# Distributed Coordination
+
+The moment you run more than one copy of your app, cron gets awkward. Three replicas behind a load balancer, a PM2 cluster, a Kubernetes Deployment scaled to 4 pods, a blue/green rollout with both colors live for a minute, all of them have the same code, so all of them schedule the same job, and the nightly backup runs **four times** instead of once.
+
+`distributed: true` solves that: the task fires on exactly **one instance per scheduled time**, across the whole fleet.
+
+```js
+import cron from 'node-cron';
+
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup',
+  distributed: true,
+});
+```
+
+Two things are required and one is the question that drives everything else:
+
+- It is **opt-in per task** (`distributed: true`); other tasks keep running everywhere.
+- It needs a **`name`** (it forms the coordination key shared across instances; the auto-generated id is per-process and can't coordinate).
+- And it asks one question on every fire: **"should *this* instance run *this* time?"** The thing that answers is the **run coordinator**.
+
+## The default: one designated runner
+
+Out of the box, node-cron answers that question with an environment variable, `NODE_CRON_RUN`, no extra dependencies, no Redis. You designate **one** instance as the runner:
+
+```bash
+# instance A
+NODE_CRON_RUN=true   node app.js
+
+# instances B, C, D
+NODE_CRON_RUN=false  node app.js
+```
+
+Now the backup runs only on instance A; B, C, and D skip it. This is the simplest correct answer to "stop running my cron N times," and for many fleets it's all you need: your orchestrator already decides which pod is special (a `StatefulSet`, a single-replica `Deployment`, a dedicated worker dyno), so let it set the flag.
+
+There is **no default value**. If a `distributed` task is scheduled and `NODE_CRON_RUN` is unset (or isn't exactly `'true'`/`'false'`), node-cron **throws at schedule time**, on startup, not silently at 3 a.m.:
+
+```
+node-cron: a `distributed` task needs NODE_CRON_RUN set to 'true' or 'false'.
+Set it to 'true' on exactly one instance and 'false' on the others, or provide
+a coordinator via cron.setRunCoordinator(...).
+```
+
+This is deliberate. A silent default could only do one of two wrong things, run everywhere (the duplicates you came here to fix) or run nowhere (a backup that quietly never happens). Failing loudly on deploy is the safe choice.
+
+::: tip This is not high availability
+The env-var default is a *single designated runner*. If instance A is down at 3 a.m., the backup doesn't run, B, C, and D were told `false`. For a fleet where **any** instance can take over, read on.
+:::
+
+## The guarantee
+
+With coordination in place, node-cron guarantees **no concurrent execution across instances**, effectively *once per fire* when the instances' clocks are in sync.
+
+It is **not** a hard exactly-once: under a crash-and-retry, or large clock skew between instances, a fire could still run more than once. Treat distributed tasks as **idempotent** (safe to run twice) and you're covered for the rare edge. This is a coordination primitive, not a transactional queue, if you need durable, exactly-once job semantics, reach for a queue like BullMQ.
+
+## High availability: a custom run coordinator
+
+The env-var default trades availability for simplicity. To let **any** instance run a fire, only never two at once, you provide a **run coordinator** backed by something the whole fleet shares (typically Redis). Now there's no special instance: every replica races for each fire, exactly one wins, and if the winner is down another takes over.
+
+A coordinator is just an object that answers the question:
+
+```ts
+interface RunCoordinator {
+  // true  -> this instance runs the fire identified by `key`
+  // false -> skip it (another instance handles it)
+  // throw -> fail closed (skip), e.g. the backend is unreachable
+  shouldRun(key: string, ttlMs: number): boolean | Promise<boolean>;
+
+  // called after the run completes (success or failure); e.g. release a lock
+  onComplete?(key: string): void | Promise<void>;
+}
+```
+
+Register one globally with `setRunCoordinator`, and it's used for every `distributed` task instead of the env-var default:
+
+```js
+import cron, { setRunCoordinator } from 'node-cron';
+import { RedisLockCoordinator } from '@node-cron/redis-coordinator';
+
+setRunCoordinator(new RedisLockCoordinator(redis));
+
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup',
+  distributed: true, // now HA: any instance can run it, only one wins
+});
+```
+
+Under the hood a Redis coordinator turns `shouldRun` into an atomic "claim this key" (`SET key NX PX ttl`) and `onComplete` into a safe release, so for the fire keyed `nightly-backup:2026-06-17T03:00:00.000Z`, the first instance to claim it wins and the rest get `false`.
+
+::: info `@node-cron/redis-coordinator`
+The Redis-backed coordinator ships as a separate package so the core stays dependency-free. Until then, any object implementing the `RunCoordinator` interface works, the contract above is the whole API.
+:::
+
+### Per-task coordinator
+
+A coordinator can also be set on a single task, overriding the global one:
+
+```js
+cron.schedule('*/5 * * * *', syncInventory, {
+  name: 'sync-inventory',
+  distributed: true,
+  runCoordinator: myCoordinator, // wins over setRunCoordinator() and the env default
+});
+```
+
+Resolution order: per-task `runCoordinator` → global `setRunCoordinator` → the env-var default.
+
+## Knowing when an instance skips
+
+When an instance is **not** the one chosen to run a fire, it emits [`execution:skipped`](/event-listening) instead of running. The context carries a `reason`:
+
+```js
+task.on('execution:skipped', (ctx) => {
+  if (ctx.reason === 'coordinator-error') {
+    // the coordinator failed (e.g. Redis down) and we failed closed.
+    // this is the one to alert on: the fire may not have run anywhere.
+    alert('cron coordination is failing', ctx);
+  }
+  // ctx.reason === 'not-elected' is the healthy case: another instance ran it.
+});
+```
+
+| `reason`             | Meaning                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `'not-elected'`      | Healthy. Another instance was chosen for this fire.                                      |
+| `'coordinator-error'`| The coordinator threw (e.g. the backend was unreachable). node-cron **failed closed** and skipped, so the fire may not have run on any instance. Alert on this. |
+
+The instance that *does* run emits the normal [`execution:started` → `execution:finished`](/event-listening) sequence, so "did this instance run it?" is just "did I get `execution:started`?", no extra event needed.
+
+## `distributedTtl`
+
+Lease-based coordinators (like a Redis lock) hold the claim for a safety window in case the winner crashes mid-run without releasing it. `distributedTtl` (ms, default `30000`) sets that lease, and it **must exceed the task's run time**, or the lease can expire mid-run and another instance could start a second copy. The env-var default ignores it.
+
+```js
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup',
+  distributed: true,
+  distributedTtl: 5 * 60_000, // the backup can take up to ~5 minutes
+});
+```
+
+## Background tasks work too
+
+`distributed` works for [background tasks](/background-tasks) exactly as for inline ones, you set the coordinator in your main process and it applies transparently. Internally the forked daemon can't hold the coordinator (it lives across a process boundary), so it asks the parent over IPC, and the parent runs the real coordinator. The shared backend still arbitrates across the fleet; you don't configure anything extra.
+
+```js
+// in your main process
+setRunCoordinator(new RedisLockCoordinator(redis));
+
+cron.schedule('0 3 * * *', './tasks/backup.js', {
+  name: 'nightly-backup',
+  distributed: true,
+});
+```
+
+## A note on `maxExecutions`
+
+[`maxExecutions`](/scheduling-options) is counted **per instance**. With a per-fire coordinator (the HA case), each instance only counts the fires it won, so the fleet total can exceed your limit. With the single-runner env-var default it behaves as expected, only the designated instance runs and counts.
+
+## How it works internally
+
+On each fire of a `distributed` task, node-cron builds a key from the task's `name` and the exact scheduled time (`name:fireTimeISO`), so every instance computes the **same** key for the **same** fire. It calls `shouldRun(key, ttl)`; on `true` it runs the task and then calls `onComplete(key)`; on `false` (or a thrown error) it emits `execution:skipped` and moves on. The coordinator is where cross-instance agreement happens, node-cron itself stays a scheduler.
+
+## Next steps
+
+- **[Events & Observability](/event-listening)**: handle `execution:skipped` and the rest of the lifecycle.
+- [Background Tasks](/background-tasks): run the work in an isolated process; coordination still applies.
+- [Scheduling Options](/scheduling-options): the full list of options, including `distributed`, `runCoordinator`, and `distributedTtl`.

--- a/src/event-listening.md
+++ b/src/event-listening.md
@@ -41,6 +41,7 @@ task.on('execution:failed', (ctx) => {
 | `execution:missed`     | `TaskContext` | A scheduled run was missed (blocking I/O or high CPU).           |
 | `execution:overlap`    | `TaskContext` | A run was skipped because a previous one was still going (`noOverlap`). |
 | `execution:maxReached` | `TaskContext` | `maxExecutions` was reached. The task is then destroyed.         |
+| `execution:skipped`    | `TaskContext` | A [`distributed`](/distributed-coordination) run was skipped on this instance. `ctx.reason` is `'not-elected'` (another instance ran it) or `'coordinator-error'` (the coordinator failed; failed closed). |
 
 ## Subscribing
 
@@ -79,6 +80,7 @@ export type TaskContext = {
   triggeredAt: Date;
   task?: ScheduledTask;
   execution?: Execution;
+  reason?: 'not-elected' | 'coordinator-error';
 };
 ```
 
@@ -89,6 +91,7 @@ export type TaskContext = {
 | `triggeredAt`  | `Date`           | When the event was actually emitted. Useful for spotting drift.       |
 | `task`         | `ScheduledTask?` | The task instance.                                                    |
 | `execution`    | `Execution?`     | Details of the run (present for `execution:*` events).                |
+| `reason`       | `string?`        | Why a run was skipped. Present only on [`execution:skipped`](/distributed-coordination#knowing-when-an-instance-skips): `'not-elected'` or `'coordinator-error'`. |
 
 ### Execution
 

--- a/src/scheduling-options.md
+++ b/src/scheduling-options.md
@@ -24,6 +24,9 @@ export type Options = {
   logger?: Logger;
   suppressMissedWarning?: boolean;
   missedExecutionTolerance?: number;
+  distributed?: boolean;             // run on one instance per fire across a fleet
+  runCoordinator?: RunCoordinator;   // per-task coordinator (overrides the global one)
+  distributedTtl?: number;           // lease ms for lease-based coordinators (default 30000)
   executeTimeout?: number; // background tasks only
   startTimeout?: number;   // background tasks only
 };
@@ -39,6 +42,9 @@ export type Options = {
 | `logger`                | `Logger`  | global  | A custom [logger](/logging) for this task, overriding the global one. **Not supported for [background tasks](/background-tasks).** |
 | `suppressMissedWarning` | `boolean` | `false` | Silences the "missed execution" warning for this task. See [Logging](/logging#suppressing-the-missed-execution-warning). |
 | `missedExecutionTolerance` | `number` | `1000` | How late (in ms) a scheduled run may wake and still execute instead of being reported as missed. Long timers drift (OS sleep, GC, throttling, clock skew), which can otherwise skip daily/weekly runs. Always capped to the gap to the next run, so it can never run a slot twice. |
+| `distributed`           | `boolean` | `false` | Run this task on a **single instance per fire** across a fleet. Requires a `name`. Uses the `NODE_CRON_RUN` env-var default (one designated runner) unless a coordinator is set. See [Distributed Coordination](/distributed-coordination). |
+| `runCoordinator`        | `RunCoordinator` | global | A per-task [run coordinator](/distributed-coordination#high-availability-a-custom-run-coordinator), overriding the one set with `setRunCoordinator`. Only used when `distributed` is `true`. |
+| `distributedTtl`        | `number`  | `30000` | Lease expiry (ms) passed to lease-based coordinators (e.g. a Redis lock) in case the holder crashes mid-run. Must exceed the run time. Ignored by the env-var default. |
 
 > 🛈 There is no `scheduled` or `runOnInit` option anymore. Tasks created with `cron.schedule` start immediately; for a task that starts stopped, use [`cron.createTask`](/task-lifecycle#creating-a-stopped-task). To run a task immediately on demand, call [`task.execute()`](/task-lifecycle#execute). See [Migrating from v3](/migrating-from-v3).
 
@@ -115,6 +121,21 @@ const task = cron.schedule('0 * * * *', () => {
   maxRandomDelay: 30_000, // up to 30s of random delay per run
 });
 ```
+
+### Run on one instance across a fleet
+
+When several copies of your app run the same schedule, `distributed` makes a task fire on only one instance per scheduled time. Out of the box you designate the runner with the `NODE_CRON_RUN` env var; for high availability, register a [run coordinator](/distributed-coordination#high-availability-a-custom-run-coordinator) (e.g. Redis):
+
+```js
+import cron from 'node-cron';
+
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup', // required: forms the coordination key
+  distributed: true,
+});
+```
+
+A not-elected instance emits [`execution:skipped`](/event-listening) instead of running. See [Distributed Coordination](/distributed-coordination) for the full picture.
 
 ### Name a task
 

--- a/src/task-lifecycle.md
+++ b/src/task-lifecycle.md
@@ -78,6 +78,14 @@ export interface ScheduledTask {
   getStatus(): string;
   getNextRun(): Date | null;
 
+  // Inspection
+  getNextRuns(count: number): Date[];
+  match(date: Date): boolean;
+  msToNext(): number | null;
+  isBusy(): boolean;
+  runsLeft(): number | undefined;
+  getPattern(): string;
+
   on(event: TaskEvent, fn: (context: TaskContext) => void | Promise<void>): void;
   off(event: TaskEvent, fn: (context: TaskContext) => void | Promise<void>): void;
   once(event: TaskEvent, fn: (context: TaskContext) => void | Promise<void>): void;
@@ -151,6 +159,69 @@ import cron from 'node-cron';
 
 const task = cron.schedule('0 * * * *', () => {});
 console.log(task.getNextRun()); // e.g. 2026-06-16T15:00:00.000Z
+```
+
+## Inspecting a task
+
+Beyond status and the next run, a task exposes a few read-only methods for previewing its schedule and seeing what it's doing right now, handy for dashboards, health checks, and tests. They work the same for inline and background tasks.
+
+### `getNextRuns(count)`
+
+Returns the next `count` run times as an array of `Date`s, strictly increasing. Useful for previewing a schedule ("when will this fire next?") without waiting.
+
+```js
+import cron from 'node-cron';
+
+const task = cron.schedule('0 0 12 * * *', () => {});
+task.getNextRuns(3);
+// [ 2026-06-18T12:00:00.000Z, 2026-06-19T12:00:00.000Z, 2026-06-20T12:00:00.000Z ]
+```
+
+A non-positive `count` returns an empty array. Unlike [`getNextRun()`](#getnextrun), this works regardless of the task's state (it computes from the expression).
+
+### `match(date)`
+
+Returns `true` if the given `Date` matches the task's cron expression (evaluated in the task's timezone).
+
+```js
+const task = cron.schedule('0 0 12 * * *', () => {}, { timezone: 'Etc/UTC' });
+task.match(new Date('2026-06-18T12:00:00Z')); // true
+task.match(new Date('2026-06-18T12:00:01Z')); // false
+```
+
+### `msToNext()`
+
+Milliseconds from now until the next run, or `null` when the task is stopped.
+
+```js
+const task = cron.schedule('0 * * * *', () => {});
+task.msToNext(); // e.g. 1830000
+```
+
+### `isBusy()`
+
+`true` while an execution is in progress (the task is in the `running` state), `false` otherwise. Useful before triggering work or shutting down.
+
+```js
+if (!task.isBusy()) await task.execute();
+```
+
+### `runsLeft()`
+
+When [`maxExecutions`](/scheduling-options) is set, the number of runs remaining before the task destroys itself; otherwise `undefined`.
+
+```js
+const task = cron.schedule('* * * * * *', () => {}, { maxExecutions: 3 });
+task.runsLeft(); // 3, then 2, 1, 0
+```
+
+### `getPattern()`
+
+Returns the original cron expression the task was created with.
+
+```js
+const task = cron.schedule('0 0 12 * * *', () => {});
+task.getPattern(); // '0 0 12 * * *'
 ```
 
 ## Creating a stopped task


### PR DESCRIPTION
Documents the features shipped in node-cron since v4.3.0 (introspection #547, `parse`/`validateDetailed` #548, distributed coordination #549), following the existing page patterns (storytelling intro, `description` frontmatter, option/event tables, code-groups, cross-linked "Next steps").

## New page
- **Distributed Coordination** (Scaling Up): the fleet/duplicate-run problem → `distributed: true` + `name` → the `NODE_CRON_RUN` single-runner default (fails fast on a missing env) → the `RunCoordinator` interface + `setRunCoordinator` for HA (Redis) → `execution:skipped` reasons (`not-elected` / `coordinator-error`) → `distributedTtl`, background tasks, and the `maxExecutions` caveat.

## Updated pages
- **Task Lifecycle & Status**: documents the inspection methods (`getNextRuns`, `match`, `msToNext`, `isBusy`, `runsLeft`, `getPattern`) and adds them to the `ScheduledTask` interface.
- **API Reference**: adds `validateDetailed`, `parse`, and `setRunCoordinator`; extends the `Options` block with `distributed` / `runCoordinator` / `distributedTtl`.
- **Scheduling Options**: the three new options (type, table, example).
- **Events & Observability**: the `execution:skipped` event and `context.reason`.
- **Cron Syntax**: the `validateDetailed` / `parse` helpers.
- **Sidebar**: registers the new page.

## Accuracy
`validateDetailed` / `parse` examples were run against the real build (field names, the `fields` key, the actual throw message). `docs:build` passes with no dead links; the new page is included in the generated `llms.txt` / `llms-full.txt`.