### PR TITLE
docs: rename distributedTtl to distributedLease

### DIFF
--- a/src/api-reference.md
+++ b/src/api-reference.md
@@ -50,7 +50,7 @@ type Options = {
   missedExecutionTolerance?: number // ms a late run may still execute (default 1000)
   distributed?: boolean;          // run on one instance per fire across a fleet
   runCoordinator?: RunCoordinator;// per-task coordinator (overrides the global one)
-  distributedTtl?: number;        // lease ms for lease-based coordinators (default 30000)
+  distributedLease?: number;        // lease ms for lease-based coordinators (default 30000)
 };
 ```
 

--- a/src/distributed-coordination.md
+++ b/src/distributed-coordination.md
@@ -133,15 +133,15 @@ task.on('execution:skipped', (ctx) => {
 
 The instance that *does* run emits the normal [`execution:started` → `execution:finished`](/event-listening) sequence, so "did this instance run it?" is just "did I get `execution:started`?", no extra event needed.
 
-## `distributedTtl`
+## `distributedLease`
 
-Lease-based coordinators (like a Redis lock) hold the claim for a safety window in case the winner crashes mid-run without releasing it. `distributedTtl` (ms, default `30000`) sets that lease, and it **must exceed the task's run time**, or the lease can expire mid-run and another instance could start a second copy. The env-var default ignores it.
+Lease-based coordinators (like a Redis lock) hold the claim for a safety window in case the winner crashes mid-run without releasing it. `distributedLease` (ms, default `30000`) sets that lease, and it **must exceed the task's run time**, or the lease can expire mid-run and another instance could start a second copy. The env-var default ignores it.
 
 ```js
 cron.schedule('0 3 * * *', runNightlyBackup, {
   name: 'nightly-backup',
   distributed: true,
-  distributedTtl: 5 * 60_000, // the backup can take up to ~5 minutes
+  distributedLease: 5 * 60_000, // the backup can take up to ~5 minutes
 });
 ```
 
@@ -171,4 +171,4 @@ On each fire of a `distributed` task, node-cron builds a key from the task's `na
 
 - **[Events & Observability](/event-listening)**: handle `execution:skipped` and the rest of the lifecycle.
 - [Background Tasks](/background-tasks): run the work in an isolated process; coordination still applies.
-- [Scheduling Options](/scheduling-options): the full list of options, including `distributed`, `runCoordinator`, and `distributedTtl`.
+- [Scheduling Options](/scheduling-options): the full list of options, including `distributed`, `runCoordinator`, and `distributedLease`.

--- a/src/scheduling-options.md
+++ b/src/scheduling-options.md
@@ -26,7 +26,7 @@ export type Options = {
   missedExecutionTolerance?: number;
   distributed?: boolean;             // run on one instance per fire across a fleet
   runCoordinator?: RunCoordinator;   // per-task coordinator (overrides the global one)
-  distributedTtl?: number;           // lease ms for lease-based coordinators (default 30000)
+  distributedLease?: number;           // lease ms for lease-based coordinators (default 30000)
   executeTimeout?: number; // background tasks only
   startTimeout?: number;   // background tasks only
 };
@@ -44,7 +44,7 @@ export type Options = {
 | `missedExecutionTolerance` | `number` | `1000` | How late (in ms) a scheduled run may wake and still execute instead of being reported as missed. Long timers drift (OS sleep, GC, throttling, clock skew), which can otherwise skip daily/weekly runs. Always capped to the gap to the next run, so it can never run a slot twice. |
 | `distributed`           | `boolean` | `false` | Run this task on a **single instance per fire** across a fleet. Requires a `name`. Uses the `NODE_CRON_RUN` env-var default (one designated runner) unless a coordinator is set. See [Distributed Coordination](/distributed-coordination). |
 | `runCoordinator`        | `RunCoordinator` | global | A per-task [run coordinator](/distributed-coordination#high-availability-a-custom-run-coordinator), overriding the one set with `setRunCoordinator`. Only used when `distributed` is `true`. |
-| `distributedTtl`        | `number`  | `30000` | Lease expiry (ms) passed to lease-based coordinators (e.g. a Redis lock) in case the holder crashes mid-run. Must exceed the run time. Ignored by the env-var default. |
+| `distributedLease`        | `number`  | `30000` | Lease expiry (ms) passed to lease-based coordinators (e.g. a Redis lock) in case the holder crashes mid-run. Must exceed the run time. Ignored by the env-var default. |
 
 > 🛈 There is no `scheduled` or `runOnInit` option anymore. Tasks created with `cron.schedule` start immediately; for a task that starts stopped, use [`cron.createTask`](/task-lifecycle#creating-a-stopped-task). To run a task immediately on demand, call [`task.execute()`](/task-lifecycle#execute). See [Migrating from v3](/migrating-from-v3).
 


### PR DESCRIPTION
Follows node-cron#551, which renames the `distributedTtl` task option to `distributedLease` (drops the lone abbreviation in the options API, groups with `distributed`). Updates the Distributed Coordination page, Scheduling Options, and API Reference accordingly. `docs:build` passes.