### PR TITLE
docs: add a blog + first post (node-cron at scale)

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -33,7 +33,6 @@ export default defineConfig({
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Quickstart', link: '/getting-started' },
-      { text: 'NestJS', link: '/nestjs' },
       { text: 'API Reference', link: '/api-reference' },
       { text: 'Blog', link: '/blog/' },
     ],

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
       { text: 'Quickstart', link: '/getting-started' },
       { text: 'NestJS', link: '/nestjs' },
       { text: 'API Reference', link: '/api-reference' },
+      { text: 'Blog', link: '/blog/' },
     ],
 
     sidebar: [

--- a/src/blog/index.md
+++ b/src/blog/index.md
@@ -1,0 +1,30 @@
+---
+title: Blog
+description: Release notes, deep dives, and positioning for node-cron, the lightweight task scheduler for Node.js. Distributed scheduling, NestJS, and more.
+sidebar: false
+aside: false
+---
+
+<script setup>
+import { data as posts } from './posts.data.mts'
+</script>
+
+# Blog
+
+Deep dives and release stories behind node-cron, what shipped, why, and what it unlocks.
+
+<ul class="blog-index">
+  <li v-for="post of posts" :key="post.url">
+    <a :href="post.url">{{ post.title }}</a>
+    <div class="blog-meta">{{ post.displayDate }}</div>
+    <p>{{ post.description }}</p>
+  </li>
+</ul>
+
+<style scoped>
+.blog-index { list-style: none; padding: 0; }
+.blog-index li { margin: 0 0 1.75rem; }
+.blog-index a { font-size: 1.2rem; font-weight: 600; }
+.blog-meta { color: var(--vp-c-text-2); font-size: 0.85rem; margin: 0.15rem 0 0.35rem; }
+.blog-index p { margin: 0; color: var(--vp-c-text-2); }
+</style>

--- a/src/blog/node-cron-at-scale.md
+++ b/src/blog/node-cron-at-scale.md
@@ -1,0 +1,71 @@
+---
+title: "node-cron at scale: one fire, one instance, no queue"
+date: 2026-06-18
+author: Lucas Merencia
+description: "The myth that node-cron is not for production fleets is outdated. With distributed: true and a run coordinator, a scheduled job fires once across N instances, no queue required. Here is how it works."
+sidebar: false
+---
+
+# node-cron at scale: one fire, one instance, no queue
+
+There is a recurring belief that node-cron is a single-box toy: fine for one process, but the moment you run more than one instance it falls apart. The reasoning goes: three replicas behind a load balancer all run the same `cron.schedule(...)`, so the nightly backup runs three times, therefore "node-cron does not scale," therefore reach for a queue or a different tool.
+
+That belief is out of date. As of **4.4.x**, node-cron coordinates a job to fire on exactly **one instance per scheduled time** across a whole fleet.
+
+## The problem was never node-cron
+
+The duplicate run is not a node-cron bug. It is what happens when you run the **same schedule in N processes**: every in-process scheduler does it. The question was never "is the scheduler good," it was "who decides which instance runs this fire?" node-cron now answers that, with a small, explicit primitive.
+
+You opt in per task:
+
+```js
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup',
+  distributed: true,
+});
+```
+
+Two things happen. The task asks a **run coordinator** one question on each fire, "should this instance run this one?", and only the instance that gets `true` runs it. The rest emit `execution:skipped` and move on.
+
+## Zero dependencies out of the box
+
+You do not need Redis to stop double-firing. The built-in default coordinates through an environment variable: set `NODE_CRON_RUN=true` on one instance and `false` on the others, and the job runs only on the designated one.
+
+```bash
+NODE_CRON_RUN=true   node app.js   # the runner
+NODE_CRON_RUN=false  node app.js   # everyone else
+```
+
+No new dependency, no infrastructure. If your orchestrator already has a notion of a "primary" instance (a single-replica Deployment, a dedicated worker), this is all you need. And it fails loud: if a `distributed` task is scheduled without the variable set, node-cron throws at startup rather than silently running everywhere or nowhere.
+
+## Redis for true high availability
+
+The env-var default has one weakness: if the designated instance is down at 3 a.m., nothing runs. For real HA, install [`@node-cron/redis-coordinator`](/distributed-coordination#the-redis-coordinator) and any instance can win each fire, with no single point of failure:
+
+```js
+import { RedisLockCoordinator } from '@node-cron/redis-coordinator';
+
+cron.setRunCoordinator(new RedisLockCoordinator(redis)); // your existing client
+```
+
+Now every replica races for each fire, exactly one wins (an atomic Redis lock keyed by `name:fireTime`), and if the winner crashes, the next fire is wide open for another node. You reuse the Redis you almost certainly already run; the coordinator brings no client of its own.
+
+## "But don't I need a queue for this?"
+
+Usually, no, and this is the crux. A queue like BullMQ solves **durable work distribution**: jobs that must survive restarts, retry with backoff, fan out to workers, apply backpressure. That is a real and different need.
+
+"Run this scheduled job once across my fleet" is not that. It is a **coordination** problem, and coordinating a boolean ("did I win this fire?") is far lighter than standing up a queue, a worker topology, and the operational weight that comes with it. If a queue is solving only your double-fire problem, it is the wrong size of tool. node-cron plus a lock is the right one.
+
+What you do **not** get is hard exactly-once. The guarantee is **no concurrent execution across instances**, effectively once when clocks are in sync, but a crash-and-retry or large clock skew can still run a fire twice. So make distributed jobs **idempotent** and you are covered. (If you genuinely need transactional exactly-once, that is the queue's job, not a scheduler's.)
+
+## Heavy jobs, too
+
+The same `distributed: true` works on [background tasks](/background-tasks), jobs that run in a forked child process so heavy work never blocks your event loop. The coordinator lives in the parent and the child coordinates through it, so a CPU-bound report can run in isolation **and** only on one instance of the fleet.
+
+## The takeaway
+
+node-cron is a scheduler, not a queue, and that is the point. For the common case, "run my scheduled jobs reliably, including across a fleet," it now has a first-class, honest answer that scales from one box (an env var) to an HA cluster (a Redis lock) without dragging in a queue you did not need.
+
+- Full guide: [Distributed Coordination](/distributed-coordination)
+- The Redis coordinator: [`@node-cron/redis-coordinator`](https://www.npmjs.com/package/@node-cron/redis-coordinator)
+- Running NestJS? The same coordination is one option away in [`@node-cron/nestjs`](/nestjs).

--- a/src/blog/posts.data.mts
+++ b/src/blog/posts.data.mts
@@ -1,0 +1,32 @@
+import { createContentLoader } from 'vitepress'
+
+interface Post {
+  title: string
+  url: string
+  description: string
+  date: string
+  displayDate: string
+}
+
+declare const data: Post[]
+export { data }
+
+export default createContentLoader('blog/*.md', {
+  transform(raw): Post[] {
+    return raw
+      // drop the index page itself
+      .filter((page) => !page.url.endsWith('/blog/') && !page.url.endsWith('/blog/index'))
+      .map(({ url, frontmatter }) => ({
+        title: frontmatter.title as string,
+        url,
+        description: (frontmatter.description as string) ?? '',
+        date: frontmatter.date as string,
+        displayDate: new Date(frontmatter.date as string).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        }),
+      }))
+      .sort((a, b) => +new Date(b.date) - +new Date(a.date))
+  },
+})


### PR DESCRIPTION
A place to post release-anchored, myth-busting positioning content (your call from the chat: explain releases, e.g. "node-cron isn't for scale" is solved with the Redis coordinator).

## What this adds
- **Blog section** under `src/blog/` with an auto-generated index (`createContentLoader`, sorted by date) and a **Blog** nav item.
- **First post: "node-cron at scale: one fire, one instance, no queue"** — reframes the duplicate-execution myth as a coordination problem, walks the env-var default (zero deps) and `@node-cron/redis-coordinator` (HA), is honest about the not-exactly-once guarantee, and argues why a queue is the wrong-size tool for "run once across a fleet". Links to the Distributed Coordination guide, the Redis package, and the NestJS page.

## Notes for review
- It's **opinionated/outward content** — please review the claims (especially the queue/BullMQ framing and the guarantee wording) before merging.
- Built on verified ground: every mechanism referenced (env-var default, Redis coordinator, background + distributed) was run and verified while documenting 4.4.x.
- `docs:build` passes; the index lists the post and the post page renders.

Next candidates (not in this PR): the NestJS / @nestjs/schedule story, and a **benchmarks** post (which I'd only publish with real, reproducible numbers + a script in the repo).