### PR TITLE
Add problem-oriented pages and update landing page

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   outDir: './dist',
   srcDir: './src',
   title: "node-cron",
-  description: "A Lightweight Task Scheduler for Node.js",
+  description: "Job Scheduling for Node.js",
   sitemap: {
     hostname: 'https://nodecron.com'
   },
@@ -75,6 +75,14 @@ export default defineConfig({
         text: 'Recipes',
         items: [
           { text: 'Cookbook', link: '/cookbook' },
+        ]
+      },
+      {
+        text: 'Common Problems',
+        items: [
+          { text: 'Prevent Overlapping Cron Jobs', link: '/prevent-overlapping-cron-jobs' },
+          { text: 'Cron Jobs Across Multiple Servers', link: '/run-cron-jobs-across-multiple-servers' },
+          { text: 'Background Jobs in Node.js', link: '/run-background-jobs-in-nodejs' },
         ]
       },
       {

--- a/src/index.md
+++ b/src/index.md
@@ -1,13 +1,13 @@
 ---
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
-title: node-cron, A Lightweight Task Scheduler for Node.js
-description: Schedule recurring tasks in Node.js with full cron syntax. Zero dependencies, runtime control, background processes, events, and logging. Start in one line, scale when you need to.
+title: "node-cron: Job Scheduling for Node.js"
+description: Schedule recurring tasks, prevent overlapping runs, coordinate across instances, and run heavy jobs in background processes. Zero dependencies, written in TypeScript.
 
 hero:
   name: "Node-Cron"
-  text: "A Lightweight Task Scheduler for Node.js"
-  tagline: One line to your first scheduled task, with room to grow into timezones, background processes, events, and observability.
+  text: "Job Scheduling for Node.js"
+  tagline: Schedule tasks with cron expressions. Prevent overlaps. Coordinate across instances. Run jobs in background processes. Zero dependencies.
   image:
     src: /node-cron.png
     alt: node-cron
@@ -23,17 +23,23 @@ hero:
       link: /api-reference
 
 features:
-  - title: 🔁 Standard Cron Syntax
-    details: Schedule recurring tasks with the cron expressions you already know, from seconds through weekdays, ranges, steps, lists, and month/day names.
+  - title: 🔁 Cron Scheduling
+    details: Schedule recurring tasks with standard cron expressions, from seconds through weekdays, with ranges, steps, lists, and named months/weekdays.
     link: /cron-syntax
-  - title: 🪶 Zero Dependencies
-    details: Pure JavaScript, written in TypeScript. No native bindings, no external packages. Production-ready and tiny.
-  - title: 🕹️ Full Runtime Control
-    details: Start, stop, destroy, and inspect tasks at runtime with a single consistent interface, plus lifecycle events for observability.
-    link: /task-lifecycle
+  - title: 🛡️ Overlap Prevention
+    details: Long-running task still going when the next tick fires? noOverlap skips the run instead of stacking executions. One flag, no custom locking.
+    link: /prevent-overlapping-cron-jobs
+  - title: 🌐 Distributed Coordination
+    details: Running multiple replicas? Ensure each scheduled fire executes on exactly one instance, with env-var flags or a Redis coordinator.
+    link: /run-cron-jobs-across-multiple-servers
   - title: ⚙️ Background Processes
     details: Move heavy jobs into isolated forked processes so a slow task never blocks your main event loop.
-    link: /background-tasks
+    link: /run-background-jobs-in-nodejs
+  - title: 🕹️ Runtime Control
+    details: Start, stop, destroy, and inspect tasks at runtime with a single consistent interface, plus lifecycle events for observability.
+    link: /task-lifecycle
+  - title: 🪶 Zero Dependencies
+    details: Pure JavaScript, written in TypeScript. No native bindings, no external packages. Production-ready and tiny.
 ---
 
 
@@ -52,7 +58,7 @@ cron.schedule('* * * * *', () => {
 });
 ```
 
-Later, the same task can run in a specific timezone, skip overlapping runs, report failures, and run in its own process, all without changing how you think about it:
+Later, the same task can run in a specific timezone, skip overlapping runs, coordinate across a fleet, and run in its own process:
 
 ```js
 import cron from 'node-cron';
@@ -61,12 +67,29 @@ const task = cron.schedule('0 3 * * *', './tasks/nightly-backup.js', {
   name: 'nightly-backup',
   timezone: 'America/Sao_Paulo',
   noOverlap: true,
+  distributed: true,
 });
 
 task.on('execution:failed', (ctx) => {
   console.error('backup failed:', ctx.execution?.error);
 });
 ```
+
+## When to use node-cron
+
+- Recurring jobs on a schedule (cron expressions with second-level precision)
+- Overlap prevention for long-running tasks
+- Coordinating scheduled tasks across multiple instances or replicas
+- Running heavy jobs in isolated background processes
+- Runtime control: start, stop, inspect, and observe tasks programmatically
+
+## When to consider something else
+
+- **Durable job queues with retries and priorities**: use [BullMQ](https://bullmq.io), [Agenda](https://github.com/agenda/agenda), or [Sidequest](https://sidequestjs.com)
+- **Persistent workflow orchestration**: use [Temporal](https://temporal.io) or [Inngest](https://inngest.com)
+- **Exactly-once guarantees across crashes**: node-cron coordinates but does not persist state to a database; a queue or workflow engine is a better fit
+
+## Explore the docs
 
 Follow the journey in order, or jump straight to what you need:
 
@@ -76,14 +99,12 @@ Follow the journey in order, or jump straight to what you need:
 4. **[Scheduling Options](/scheduling-options)**: timezones, overlap prevention, limits, and jitter.
 5. **[Events & Observability](/event-listening)**: react to every moment in a task's life.
 6. **[Background Tasks](/background-tasks)**: run jobs in isolated processes.
-7. **[Logging](/logging)**: route node-cron's output through your own logger.
-8. **[Cookbook](/cookbook)**: copy-paste recipes for common jobs.
+7. **[Distributed Coordination](/distributed-coordination)**: run a task on one instance per fire across a fleet.
+8. **[Logging](/logging)**: route node-cron's output through your own logger.
+9. **[Cookbook](/cookbook)**: copy-paste recipes for common jobs.
 
+## Common problems
 
-::: tip Need more than cron?
-🚀 Check out [**Sidequest.js**](https://sidequestjs.com), a distributed job runner for Node.js inspired by Oban and Sidekiq.
-
-- Supports retries, priorities, schedules, and uniqueness
-- Works with Postgres, MySQL, SQLite and MongoDB
-- Includes a clean web dashboard for real-time monitoring
-:::
+- [How to prevent overlapping cron jobs](/prevent-overlapping-cron-jobs)
+- [How to run cron jobs across multiple servers](/run-cron-jobs-across-multiple-servers)
+- [How to run background jobs in Node.js](/run-background-jobs-in-nodejs)

--- a/src/index.md
+++ b/src/index.md
@@ -83,9 +83,13 @@ task.on('execution:failed', (ctx) => {
 - Running heavy jobs in isolated background processes
 - Runtime control: start, stop, inspect, and observe tasks programmatically
 
+::: tip Need more than cron?
+Check out [**Sidequest.js**](https://sidequestjs.com), a distributed job runner for Node.js inspired by Oban and Sidekiq. Retries, priorities, schedules, uniqueness, and a web dashboard. Works with Postgres, MySQL, SQLite and MongoDB.
+:::
+
 ## When to consider something else
 
-- **Durable job queues with retries and priorities**: use [BullMQ](https://bullmq.io), [Agenda](https://github.com/agenda/agenda), or [Sidequest](https://sidequestjs.com)
+- **Durable job queues with retries and priorities**: use [Sidequest](https://sidequestjs.com), [BullMQ](https://bullmq.io), or [Agenda](https://github.com/agenda/agenda)
 - **Persistent workflow orchestration**: use [Temporal](https://temporal.io) or [Inngest](https://inngest.com)
 - **Exactly-once guarantees across crashes**: node-cron coordinates but does not persist state to a database; a queue or workflow engine is a better fit
 

--- a/src/prevent-overlapping-cron-jobs.md
+++ b/src/prevent-overlapping-cron-jobs.md
@@ -1,0 +1,116 @@
+---
+outline: deep
+title: How to Prevent Overlapping Cron Jobs in Node.js
+description: Prevent duplicate cron executions when a task runs longer than its interval. One option, no external locking, built into node-cron.
+---
+
+# How to Prevent Overlapping Cron Jobs in Node.js
+
+A cron job scheduled to run every minute takes 90 seconds to finish. Now two copies are running at once: the first is still going, and the second just started. This is an overlapping execution, and it causes duplicate work, race conditions, and data corruption.
+
+## The problem
+
+Without overlap prevention, a scheduler fires on every tick regardless of whether the previous run finished:
+
+```
+minute 1: task starts ──────────────────────── still running
+minute 2:               task starts (overlap!) ──────────
+minute 3:                              task starts (overlap!) ───
+```
+
+Common symptoms:
+- Duplicate database writes
+- Double-sent emails or notifications
+- API rate limits exceeded
+- Resource exhaustion from piled-up processes
+
+## The solution: `noOverlap`
+
+node-cron has built-in overlap prevention. Set `noOverlap: true` and a tick that fires while the previous run is still active is skipped instead of stacked:
+
+```js
+import cron from 'node-cron';
+
+cron.schedule('* * * * *', async () => {
+  await longRunningJob();
+}, {
+  noOverlap: true,
+});
+```
+
+```
+minute 1: task starts ──────────────────────── finishes
+minute 2:               (skipped, previous still running)
+minute 3:                                       task starts ───
+```
+
+No external locking, no Redis, no database. It works in-process with zero configuration beyond the flag.
+
+## Detecting skipped runs
+
+When a run is skipped due to overlap, the task emits an `execution:overlap` event. Use it for logging, metrics, or alerting:
+
+```js
+const task = cron.schedule('* * * * *', async () => {
+  await longRunningJob();
+}, {
+  noOverlap: true,
+});
+
+task.on('execution:overlap', () => {
+  console.warn('Skipped: previous execution still running');
+});
+```
+
+## Combining with other features
+
+`noOverlap` works with every other node-cron feature:
+
+### With background tasks
+
+```js
+cron.schedule('*/5 * * * *', './tasks/heavy-sync.js', {
+  noOverlap: true,
+});
+```
+
+The job runs in an isolated forked process, and the scheduler still tracks whether it is active.
+
+### With distributed coordination
+
+```js
+cron.schedule('0 * * * *', syncInventory, {
+  name: 'sync-inventory',
+  noOverlap: true,
+  distributed: true,
+});
+```
+
+Only one instance in the fleet runs each fire, and within that instance, overlapping runs are prevented.
+
+### With events and observability
+
+```js
+const task = cron.schedule('*/30 * * * * *', processQueue, {
+  noOverlap: true,
+});
+
+task.on('execution:started', () => console.log('started'));
+task.on('execution:finished', (ctx) => console.log('done:', ctx.execution?.result));
+task.on('execution:failed', (ctx) => console.error('failed:', ctx.execution?.error));
+task.on('execution:overlap', () => console.warn('skipped: still running'));
+```
+
+## When overlap prevention is not enough
+
+`noOverlap` prevents concurrent executions of the same task within a single process (or a single instance when combined with `distributed`). For scenarios that need more:
+
+- **Cross-process locking without node-cron's distributed mode**: use a Redis lock or database advisory lock directly.
+- **Durable job queues with retries**: use [BullMQ](https://bullmq.io) or [Sidequest](https://sidequestjs.com), which persist jobs to a backend and handle retries, priorities, and deduplication.
+- **Exactly-once execution guarantees**: use a transactional queue or workflow engine.
+
+## Next steps
+
+- [Scheduling Options](/scheduling-options): all options including `noOverlap`, `maxExecutions`, and `maxRandomDelay`.
+- [Events & Observability](/event-listening): the full list of lifecycle events.
+- [How to run cron jobs across multiple servers](/run-cron-jobs-across-multiple-servers): coordinate tasks across a fleet.

--- a/src/prevent-overlapping-cron-jobs.md
+++ b/src/prevent-overlapping-cron-jobs.md
@@ -18,12 +18,6 @@ minute 2:               task starts (overlap!) ──────────
 minute 3:                              task starts (overlap!) ───
 ```
 
-Common symptoms:
-- Duplicate database writes
-- Double-sent emails or notifications
-- API rate limits exceeded
-- Resource exhaustion from piled-up processes
-
 ## The solution: `noOverlap`
 
 node-cron has built-in overlap prevention. Set `noOverlap: true` and a tick that fires while the previous run is still active is skipped instead of stacked:

--- a/src/run-background-jobs-in-nodejs.md
+++ b/src/run-background-jobs-in-nodejs.md
@@ -1,0 +1,162 @@
+---
+outline: deep
+title: How to Run Background Jobs in Node.js
+description: Run scheduled jobs in isolated forked processes so heavy work never blocks your main event loop. Built into node-cron, no external queue needed.
+---
+
+# How to Run Background Jobs in Node.js
+
+A CPU-heavy cron job blocks the event loop. While it runs, your HTTP server stops responding, WebSocket connections drop, and other scheduled tasks miss their window. The job finishes, but the collateral damage is already done.
+
+## The problem
+
+Node.js runs JavaScript on a single thread. When a scheduled task does heavy computation, file I/O, or a long synchronous operation, everything else in the process waits:
+
+```
+main thread: ──── cron fires ──── heavy job (3s) ──── blocked ────
+                                  ↑ HTTP requests queue up
+                                  ↑ other cron tasks miss their tick
+                                  ↑ WebSocket pings time out
+```
+
+Common symptoms:
+- HTTP requests timing out during scheduled jobs
+- Missed cron executions reported in logs
+- Health check failures triggering pod restarts
+- Degraded response times on a predictable schedule
+
+## The solution: background tasks
+
+node-cron can run any scheduled job in an isolated forked process. Pass a **file path** instead of a function, and the job runs in its own process, completely isolated from your main event loop:
+
+```js
+// tasks/generate-report.js
+export function task() {
+  // This runs in a separate process.
+  // Heavy computation here won't block your HTTP server.
+  return generateMonthlyReport();
+}
+```
+
+```js
+// app.js
+import cron from 'node-cron';
+
+cron.schedule('0 2 1 * *', './tasks/generate-report.js');
+```
+
+```
+main thread: ──── cron fires ──── continues serving requests ────
+forked process:   ──── heavy job (3s) ──── done ────
+```
+
+Your HTTP server keeps responding. Other cron tasks fire on time. The background job runs to completion in its own process.
+
+## Same interface, same features
+
+A background task implements the same `ScheduledTask` interface as an inline task. The only difference: control methods return Promises because they cross a process boundary.
+
+```js
+const task = cron.schedule('0 2 * * *', './tasks/report.js');
+
+await task.stop();      // terminates the child process
+await task.start();     // re-forks and resumes
+await task.destroy();   // kills the process and removes the task
+
+task.getStatus();       // 'idle', 'running', etc.
+task.getNextRun();      // next scheduled Date
+```
+
+## Events and observability
+
+Background tasks emit the same lifecycle events, relayed from the worker to the parent:
+
+```js
+const task = cron.schedule('0 2 * * *', './tasks/report.js');
+
+task.on('execution:started', () => console.log('report generation started'));
+task.on('execution:finished', (ctx) => console.log('done:', ctx.execution?.result));
+task.on('execution:failed', (ctx) => console.error('failed:', ctx.execution?.error));
+```
+
+## Manual execution
+
+Trigger a background task immediately with `execute()`:
+
+```js
+const task = cron.schedule('0 2 * * *', './tasks/report.js');
+
+const result = await task.execute();
+```
+
+Guard against a worker that never reports back with `executeTimeout`:
+
+```js
+const task = cron.schedule('0 2 * * *', './tasks/report.js', {
+  executeTimeout: 60_000,
+});
+```
+
+## Combining with other features
+
+### With overlap prevention
+
+```js
+cron.schedule('*/5 * * * *', './tasks/sync.js', {
+  noOverlap: true,
+});
+```
+
+The scheduler tracks whether the forked process is still active and skips the next tick if it is.
+
+### With distributed coordination
+
+```js
+import { setRunCoordinator } from 'node-cron';
+import { RedisLockCoordinator } from '@node-cron/redis-coordinator';
+
+setRunCoordinator(new RedisLockCoordinator(redis));
+
+cron.schedule('0 3 * * *', './tasks/backup.js', {
+  name: 'nightly-backup',
+  distributed: true,
+});
+```
+
+Coordination happens in the parent process over IPC. No extra configuration needed.
+
+### With timezones
+
+```js
+cron.schedule('0 3 * * *', './tasks/backup.js', {
+  timezone: 'America/Sao_Paulo',
+});
+```
+
+## Writing a task file
+
+A task file exports a `task` function. It receives a `TaskContext` with scheduling metadata:
+
+```js
+// tasks/cleanup.js
+export function task(ctx) {
+  console.log('scheduled for:', ctx.dateLocalIso);
+  return cleanupOldRecords();
+}
+```
+
+The function can be sync or async. Its return value is available in the `execution:finished` event and through `lastRun()`.
+
+## When background tasks are not enough
+
+Background tasks isolate work from your main event loop, but the job still runs inside your Node.js application lifecycle. For scenarios that need more:
+
+- **Persistent job queues with retries**: [BullMQ](https://bullmq.io) or [Sidequest](https://sidequestjs.com) persist jobs to Redis/database and retry on failure.
+- **Worker pools**: for CPU-bound work that needs multiple parallel workers, consider [piscina](https://github.com/piscinajs/piscina) or [workerpool](https://github.com/josdejong/workerpool).
+- **External job runners**: for jobs that outlive your process, use a managed scheduler like AWS EventBridge or GCP Cloud Scheduler.
+
+## Next steps
+
+- [Background Tasks](/background-tasks): the full reference, including `startTimeout` and limitations.
+- [How to prevent overlapping cron jobs](/prevent-overlapping-cron-jobs): prevent duplicate executions.
+- [How to run cron jobs across multiple servers](/run-cron-jobs-across-multiple-servers): coordinate across instances.

--- a/src/run-background-jobs-in-nodejs.md
+++ b/src/run-background-jobs-in-nodejs.md
@@ -19,12 +19,6 @@ main thread: ──── cron fires ──── heavy job (3s) ──── bl
                                   ↑ WebSocket pings time out
 ```
 
-Common symptoms:
-- HTTP requests timing out during scheduled jobs
-- Missed cron executions reported in logs
-- Health check failures triggering pod restarts
-- Degraded response times on a predictable schedule
-
 ## The solution: background tasks
 
 node-cron can run any scheduled job in an isolated forked process. Pass a **file path** instead of a function, and the job runs in its own process, completely isolated from your main event loop:

--- a/src/run-cron-jobs-across-multiple-servers.md
+++ b/src/run-cron-jobs-across-multiple-servers.md
@@ -1,0 +1,166 @@
+---
+outline: deep
+title: How to Run Cron Jobs Across Multiple Servers in Node.js
+description: Prevent duplicate cron executions across replicas, pods, or instances. node-cron's distributed mode ensures one execution per scheduled fire across your fleet.
+---
+
+# How to Run Cron Jobs Across Multiple Servers
+
+You deploy three replicas of your Node.js app behind a load balancer. All three have the same code, the same schedule, and the same cron job. At 3 a.m., the nightly backup runs three times instead of once.
+
+This happens in every multi-instance setup: PM2 cluster mode, Kubernetes Deployments, blue/green rollouts, auto-scaling groups. The scheduler doesn't know about other copies of itself.
+
+## The problem
+
+```
+instance A: 0 3 * * * → runs backup
+instance B: 0 3 * * * → runs backup (duplicate)
+instance C: 0 3 * * * → runs backup (duplicate)
+```
+
+Common symptoms:
+- Duplicate database operations
+- Triple API calls against rate-limited services
+- Conflicting writes from concurrent backups
+- Wasted compute across the fleet
+
+## The solution: `distributed: true`
+
+node-cron has built-in distributed coordination. Set `distributed: true` and only one instance executes each scheduled fire:
+
+```js
+import cron from 'node-cron';
+
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup',
+  distributed: true,
+});
+```
+
+```
+instance A: 0 3 * * * → runs backup ✓
+instance B: 0 3 * * * → skipped (not elected)
+instance C: 0 3 * * * → skipped (not elected)
+```
+
+Two things are required:
+- A **`name`** for the task (it forms the coordination key shared across instances)
+- A way to decide which instance runs: the default uses an **env-var flag**, or you can plug in a **Redis coordinator** for high availability
+
+## Option 1: Designated runner (env-var)
+
+The simplest setup. Designate one instance as the runner:
+
+```bash
+# instance A (the runner)
+NODE_CRON_RUN=true node app.js
+
+# instances B, C, D
+NODE_CRON_RUN=false node app.js
+```
+
+This works well when your orchestrator already decides which pod is special: a StatefulSet, a single-replica Deployment, a dedicated worker dyno.
+
+If `NODE_CRON_RUN` is unset, node-cron throws at schedule time (on startup, not silently at 3 a.m.), so a misconfigured deploy fails loudly.
+
+::: warning Trade-off
+The env-var default is a single designated runner. If instance A is down at 3 a.m., the backup doesn't run. For high availability, use a coordinator.
+:::
+
+## Option 2: Redis coordinator (high availability)
+
+With a Redis coordinator, every replica races for each fire, exactly one wins, and if the winner is down another takes over:
+
+```bash
+npm install @node-cron/redis-coordinator
+```
+
+```js
+import { createClient } from 'redis';
+import cron, { setRunCoordinator } from 'node-cron';
+import { RedisLockCoordinator } from '@node-cron/redis-coordinator';
+
+const redis = createClient();
+await redis.connect();
+
+setRunCoordinator(new RedisLockCoordinator(redis));
+
+cron.schedule('0 3 * * *', runNightlyBackup, {
+  name: 'nightly-backup',
+  distributed: true,
+  distributedLease: 5 * 60_000,
+});
+```
+
+No special instance needed. Works with both [ioredis](https://github.com/redis/ioredis) and [node-redis](https://github.com/redis/node-redis) v4.
+
+## Knowing when an instance skips
+
+When an instance is not elected to run, it emits `execution:skipped`:
+
+```js
+task.on('execution:skipped', (ctx) => {
+  if (ctx.reason === 'coordinator-error') {
+    alert('coordination backend is down', ctx);
+  }
+});
+```
+
+| Reason | Meaning |
+| --- | --- |
+| `not-elected` | Healthy. Another instance ran this fire. |
+| `coordinator-error` | The coordinator failed (e.g. Redis down). The fire may not have run anywhere. Alert on this. |
+
+## Custom coordinators
+
+The Redis coordinator is one implementation of the `RunCoordinator` interface. You can back coordination with anything your fleet shares:
+
+```ts
+interface RunCoordinator {
+  shouldRun(key: string, ttlMs: number): boolean | Promise<boolean>;
+  onComplete?(key: string): void | Promise<void>;
+}
+```
+
+Postgres, etcd, DynamoDB, or any distributed lock mechanism works.
+
+## Combining with other features
+
+### With overlap prevention
+
+```js
+cron.schedule('0 * * * *', syncInventory, {
+  name: 'sync-inventory',
+  distributed: true,
+  noOverlap: true,
+});
+```
+
+One instance runs each fire, and within that instance, overlapping runs are prevented.
+
+### With background tasks
+
+```js
+setRunCoordinator(new RedisLockCoordinator(redis));
+
+cron.schedule('0 3 * * *', './tasks/backup.js', {
+  name: 'nightly-backup',
+  distributed: true,
+});
+```
+
+The forked daemon asks the parent over IPC, and the parent runs the coordinator. No extra configuration.
+
+## When distributed coordination is not enough
+
+node-cron's distributed mode guarantees no concurrent execution across instances when clocks are in sync. It is not a hard exactly-once: under a crash-and-retry or large clock skew, a fire could run more than once. Treat distributed tasks as idempotent.
+
+For stronger guarantees:
+- **Durable job queues**: [BullMQ](https://bullmq.io), [Sidequest](https://sidequestjs.com)
+- **Workflow orchestration**: [Temporal](https://temporal.io), [Inngest](https://inngest.com)
+
+## Next steps
+
+- [Distributed Coordination](/distributed-coordination): the full reference, including lease tuning and clock skew.
+- [How to prevent overlapping cron jobs](/prevent-overlapping-cron-jobs): overlap prevention within a single instance.
+- [How to run background jobs in Node.js](/run-background-jobs-in-nodejs): isolate heavy work in forked processes.

--- a/src/run-cron-jobs-across-multiple-servers.md
+++ b/src/run-cron-jobs-across-multiple-servers.md
@@ -18,12 +18,6 @@ instance B: 0 3 * * * → runs backup (duplicate)
 instance C: 0 3 * * * → runs backup (duplicate)
 ```
 
-Common symptoms:
-- Duplicate database operations
-- Triple API calls against rate-limited services
-- Conflicting writes from concurrent backups
-- Wasted compute across the fleet
-
 ## The solution: `distributed: true`
 
 node-cron has built-in distributed coordination. Set `distributed: true` and only one instance executes each scheduled fire:


### PR DESCRIPTION
## Summary

- Rewrite landing page hero: "Job Scheduling for Node.js" with 6 feature cards highlighting overlap prevention and distributed coordination
- Add "When to use" / "When to consider something else" guidance
- Add three problem-oriented pages matching common user/AI search queries:
  - /prevent-overlapping-cron-jobs
  - /run-cron-jobs-across-multiple-servers
  - /run-background-jobs-in-nodejs
- Add "Common Problems" sidebar section
- Restore Sidequest highlight above alternatives list