### PR TITLE
Add cron-translate docs page and blog post

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -65,10 +65,11 @@ export default defineConfig({
         ]
       },
       {
-        text: 'Integrations',
+        text: 'Ecosystem',
         items: [
           { text: 'NestJS', link: '/nestjs' },
           { text: 'Fastify', link: '/fastify' },
+          { text: 'Plain English to Cron', link: '/cron-translate' },
         ]
       },
       {

--- a/src/blog/plain-english-to-cron.md
+++ b/src/blog/plain-english-to-cron.md
@@ -1,0 +1,62 @@
+---
+title: "cron-translate: write schedules in plain English"
+date: 2026-06-22
+author: Lucas Merencia
+description: "Cron expressions are write-once, read-never. cron-translate turns plain English like \"every weekday at 6pm\" into the cron node-cron runs, and back. Here is how it works and the decisions behind it."
+sidebar: false
+---
+
+# cron-translate: write schedules in plain English
+
+Cron expressions are write-once, read-never. You look up `0 0 18 * * 1-5` on a syntax page, paste it into `cron.schedule`, and hope you counted the fields right. Six months later you open the file and have to look it up all over again. Nobody memorizes cron, and nobody should have to.
+
+So I built [`cron-translate`](https://github.com/node-cron/cron-translate): you write the schedule the way you would say it out loud, and it gives you the cron node-cron runs.
+
+```js
+import cron from 'node-cron';
+import { toCron } from 'cron-translate';
+
+cron.schedule(toCron('every weekday at 6pm'), () => {
+  runDailyReport();
+});
+```
+
+`every weekday at 6pm` becomes `0 0 18 * * 1-5`. No field counting, no second-guessing whether `*/5` belongs in minutes or hours. It is a sentence: one frequency, plus optional clauses for time, day, and month. `every 5 minutes at 9am`, `last friday of the month`, `every 30 minutes between 9am and 5pm on weekdays`, they all work, and every field accepts lists and ranges (`at minutes 0, 15, 30 and 45`, `on monday to friday`).
+
+## It rejects bad input instead of guessing
+
+This was the load-bearing decision. The worst thing a tool like this can do is take a phrase it does not fully understand and return a plausible-but-wrong cron. A wrong expression does not throw, it just runs your job at the wrong time, and you find out in production.
+
+So `cron-translate` does not guess. If a phrase can't become a valid expression, it throws a `CronTranslateError` with a hint. Out-of-range values (minute `99`, day `45`), conflicting clauses, things cron simply cannot express (`until christmas`, the `W` nearest-weekday character): all turned away on purpose, never silently mangled into something that runs.
+
+A library whose job is to produce correct cron has to treat "I don't understand this" as a feature, not a gap.
+
+## It is built for node-cron, not generic cron
+
+There is no single cron dialect. Five fields, six with seconds, Quartz with `L` and `#`, AWS with a year field, each numbers the days differently. A generic translator has to pick a lowest common denominator.
+
+`cron-translate` does not. It targets node-cron's 6-field format exactly, which means it can lean on what node-cron actually supports: `last friday of the month` compiles to `5L`, `first monday of the month` to `1#1`, `last day of the month` to `L`. Phrasings that only work because the runner supports them. The tool and the runner are made by the same hands, so the translation is faithful to what will really fire.
+
+## It also reads cron back to you
+
+The reverse direction matters just as much. Give `toHuman` an expression and it hands back a sentence:
+
+```js
+import { toHuman } from 'cron-translate';
+
+toHuman('0 0 18 * * 1-5'); // "at 6pm on monday to friday"
+toHuman('0 */5 9 * * *');  // "every 5 minutes at 9am"
+toHuman('0 0 0 * * 5L');   // "last friday of the month"
+```
+
+This is not a separate cron-describer competing with the existing ones. It is the confirmation half of the same tool. The English it produces is phrased so that `toCron` parses it straight back to the same expression, `toCron(toHuman(cron))` returns the original. So you can take a cron a user typed, show them what it means in their own words, and let them confirm it before it ships. The scariest part of any scheduling UI is "did it understand me?", and the readback answers it.
+
+## Small on purpose
+
+`cron-translate` does one thing. It is zero-dependency, TypeScript-native, no LLM, no network call, just a parser and a renderer. It is not trying to understand arbitrary English; it understands the phrases people actually use for schedules, and says no clearly to the rest.
+
+```bash
+npm install cron-translate
+```
+
+The docs live under [Plain English to Cron](/cron-translate), and the source is on [GitHub](https://github.com/node-cron/cron-translate). Pass its output straight into `cron.schedule` and never count cron fields again.

--- a/src/cron-syntax.md
+++ b/src/cron-syntax.md
@@ -21,6 +21,10 @@ A cron expression is how you tell node-cron *when* a task should run. `node-cron
 
 When you provide **five** fields, the seconds field defaults to `0` (the task runs at the start of the matched minute). Provide **six** fields to schedule down to the second.
 
+::: tip Prefer plain English?
+[`cron-translate`](/cron-translate) turns phrases like `every weekday at 6pm` into cron expressions (and back), so you can write `cron.schedule(toCron('every weekday at 6pm'), ...)` without hand-counting fields.
+:::
+
 ## Allowed values per field
 
 | Field          | Values                              |

--- a/src/cron-translate.md
+++ b/src/cron-translate.md
@@ -1,0 +1,116 @@
+---
+outline: deep
+title: Plain English to Cron (cron-translate)
+description: Translate plain English schedules like "every weekday at 6pm" into cron expressions for node-cron, and turn cron expressions back into readable English. Zero-dependency, TypeScript-native.
+---
+
+# Plain English to Cron
+
+[`cron-translate`](https://github.com/node-cron/cron-translate) is a companion package that converts plain English into the cron expressions node-cron runs, and back again. It is zero-dependency, TypeScript-native, and built specifically for node-cron's 6-field format.
+
+Two functions:
+
+- **`toCron(text)`** turns a phrase like `every weekday at 6pm` into `0 0 18 * * 1-5`.
+- **`toHuman(cron)`** turns a cron expression back into a readable sentence.
+
+## Install
+
+```bash
+npm install cron-translate
+```
+
+```js
+import { toCron } from 'cron-translate';
+
+toCron('every day at 9am'); // "0 0 9 * * *"
+```
+
+It ships both ESM and CommonJS builds with type declarations, and requires Node.js >= 20.
+
+## Using it with node-cron
+
+The whole point is that the output drops straight into `cron.schedule`:
+
+```js
+import cron from 'node-cron';
+import { toCron } from 'cron-translate';
+
+cron.schedule(toCron('every weekday at 6pm'), () => {
+  runDailyReport();
+});
+```
+
+No more counting fields or second-guessing whether `*/5` goes in minutes or hours.
+
+## English to cron
+
+A schedule is a sentence: one frequency, plus optional clauses for time, day, and month.
+
+```
+every <frequency> [at <time>] [on <day>] [in <month>]
+```
+
+| Input | Cron |
+|---|---|
+| `every minute` | `0 * * * * *` |
+| `every 5 minutes` | `0 */5 * * * *` |
+| `every day at noon` | `0 0 12 * * *` |
+| `every weekday at 6pm` | `0 0 18 * * 1-5` |
+| `every monday at 9am` | `0 0 9 * * 1` |
+| `every weekend` | `0 0 0 * * 0,6` |
+| `last friday of the month` | `0 0 0 * * 5L` |
+| `first monday of the month at 9am` | `0 0 9 * * 1#1` |
+
+Times can be 12-hour (`at 9am`, `at 6:30pm`), 24-hour (`at 14:30`), or words (`at noon`, `at midnight`). Day-parts work as a whole schedule (`every morning`, `every evening`).
+
+### Values, lists, and ranges
+
+Every field accepts a single value, a list, or a range. Address a field by name, or use weekday and month names:
+
+| Example | Cron |
+|---|---|
+| `at minutes 0, 15, 30 and 45` | `0 0,15,30,45 * * * *` |
+| `at minute 1 to 30` | `0 1-30 * * * *` |
+| `between 9am and 5pm` | `0 0 9-17 * * *` |
+| `on day 1 to 10` | `0 0 0 1-10 * *` |
+| `in march and june` | `0 0 0 1 3,6 *` |
+| `on monday to friday` | `0 0 0 * * 1-5` |
+
+Lists use `,` or `and`; ranges use `to` or `through`. Names and abbreviations both work (`january` / `jan`, `monday` / `mon`).
+
+### Invalid input is rejected, never guessed
+
+If a phrase can't become a valid cron expression, `toCron` throws a `CronTranslateError` instead of returning a wrong schedule. That covers unrecognized words, conflicting clauses, and out-of-range values (minute `0`-`59`, day `1`-`31`, and so on).
+
+```js
+import { toCron, CronTranslateError } from 'cron-translate';
+
+try {
+  toCron('the weekday nearest the 15th');
+} catch (err) {
+  if (err instanceof CronTranslateError) {
+    console.error(err.message, err.hint);
+  }
+}
+```
+
+A wrong cron expression runs your job at the wrong time, which is worse than an error. Things standard cron can't express (the `W` nearest-weekday character, counted recurrence like `until christmas`, arbitrary natural language) are turned away on purpose, with a hint pointing back to the [cron syntax](/cron-syntax) reference.
+
+## Cron to English
+
+`toHuman` goes the other way: give it a 5- or 6-field cron expression and it returns a readable sentence.
+
+```js
+import { toHuman } from 'cron-translate';
+
+toHuman('0 0 9 * * *');     // "at 9am"
+toHuman('0 0 18 * * 1-5');  // "at 6pm on monday to friday"
+toHuman('0 */5 9 * * *');   // "every 5 minutes at 9am"
+toHuman('0 0 0 * * 5L');    // "last friday of the month"
+```
+
+The English is phrased so that `toCron` parses it back to the same expression, so `toCron(toHuman(cron))` returns the original cron. That makes it a natural readback: take a cron a user typed, show them what it means, and let them confirm it before it ships.
+
+## Learn more
+
+Full documentation, the complete grammar, and the source are on GitHub: [node-cron/cron-translate](https://github.com/node-cron/cron-translate).


### PR DESCRIPTION
Documents the [`cron-translate`](https://github.com/node-cron/cron-translate) companion package on the site.

## Changes
- **New docs page** `src/cron-translate.md` ("Plain English to Cron"): install, using it with `node-cron`, `toCron` (English → cron) and `toHuman` (cron → English) with the round-trip property, values/lists/ranges, and the reject-don't-guess behavior.
- **Discovery callout** on the Cron Syntax page linking to it.
- **Blog post** `src/blog/plain-english-to-cron.md` announcing it and the design decisions behind it (auto-listed via `posts.data.mts`).
- **Sidebar:** consolidated NestJS, Fastify, and cron-translate under a single "Ecosystem" section (was "Integrations" with two items).

## Verified
- Every input/output example in the docs and post checked against the published `cron-translate@2.0.0`.
- `npm run docs:build` succeeds.