### PR TITLE
feat: add sponsors page with auto-update workflow

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -1,0 +1,35 @@
+name: Update sponsors
+
+on:
+  schedule:
+    - cron: "0 6 * * *"   # daily at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sponsors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate sponsors.json
+        run: npx -y @goreleaser/sponsors generate --config sponsors.yml sponsors.json
+        env:
+          # PAT with read access to the node-cron org's sponsors. The default
+          # GITHUB_TOKEN cannot read the Sponsors GraphQL API. Store as a secret.
+          GITHUB_TOKEN: ${{ secrets.SPONSORS_TOKEN }}
+
+      - name: Apply template to the sponsors page (replaces content between the markers)
+        run: npx -y @goreleaser/sponsors apply sponsors.json sponsors.tpl.md src/sponsors.md
+
+      - name: Open a PR if the sponsor list changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update sponsors"
+          title: "chore: update sponsors"
+          body: "Automated sponsor list refresh."
+          branch: chore/update-sponsors
+          delete-branch: true

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
       { text: 'Quickstart', link: '/getting-started' },
       { text: 'API Reference', link: '/api-reference' },
       { text: 'Blog', link: '/blog/' },
+      { text: 'Sponsor', link: '/sponsors' },
     ],
 
     sidebar: [

--- a/sponsors.tpl.md
+++ b/sponsors.tpl.md
@@ -1,0 +1,27 @@
+{{/*
+  Standalone template for @goreleaser/sponsors, rendered into src/sponsors.md
+  between the <!-- sponsors:begin --> / <!-- sponsors:end --> markers by:
+     npx -y @goreleaser/sponsors apply sponsors.json sponsors.tpl.md src/sponsors.md
+  Data: .Sponsors, .Tiers, .ByTier. Sponsor fields: .Name .Website .Image .LogoWithSize(size).
+*/ -}}
+<!-- auto-generated from sponsors.tpl.md by @goreleaser/sponsors, do not edit by hand -->
+{{- if .Sponsors }}
+<div class="sp-list" align="center">
+{{- with index .ByTier "gold" }}
+<p><strong>Gold</strong><br/>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 120 }}" alt="{{ .Name }}" height="80"/></a>{{ end }}</p>
+{{- end }}
+{{- with index .ByTier "silver" }}
+<p><strong>Silver</strong><br/>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 96 }}" alt="{{ .Name }}" height="60"/></a>{{ end }}</p>
+{{- end }}
+{{- with index .ByTier "bronze" }}
+<p><strong>Bronze</strong><br/>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 72 }}" alt="{{ .Name }}" height="44"/></a>{{ end }}</p>
+{{- end }}
+{{- with index .ByTier "backer" }}
+<p><strong>Backers</strong><br/>{{ range . }}<a href="{{ .Website }}">{{ .Name }}</a> &nbsp;{{ end }}</p>
+{{- end }}
+</div>
+{{- else }}
+<div class="sp-showcase">
+  node-cron doesn't have sponsors yet. <a href="https://github.com/sponsors/node-cron">Yours could be the first logo here.</a>
+</div>
+{{- end }}

--- a/sponsors.tpl.md
+++ b/sponsors.tpl.md
@@ -8,16 +8,16 @@
 {{- if .Sponsors }}
 <div class="sp-list" align="center">
 {{- with index .ByTier "gold" }}
-<p><strong>Gold</strong><br/>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 120 }}" alt="{{ .Name }}" height="80"/></a>{{ end }}</p>
+<p><strong>Gold</strong>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 130 }}" alt="{{ .Name }}" style="height:88px;width:auto"/></a>{{ end }}</p>
 {{- end }}
 {{- with index .ByTier "silver" }}
-<p><strong>Silver</strong><br/>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 96 }}" alt="{{ .Name }}" height="60"/></a>{{ end }}</p>
+<p><strong>Silver</strong>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 84 }}" alt="{{ .Name }}" style="height:54px;width:auto"/></a>{{ end }}</p>
 {{- end }}
 {{- with index .ByTier "bronze" }}
-<p><strong>Bronze</strong><br/>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 72 }}" alt="{{ .Name }}" height="44"/></a>{{ end }}</p>
+<p><strong>Bronze</strong>{{ range . }} <a href="{{ .Website }}" target="_blank" rel="noopener sponsored"><img src="{{ .LogoWithSize 56 }}" alt="{{ .Name }}" style="height:36px;width:auto"/></a>{{ end }}</p>
 {{- end }}
 {{- with index .ByTier "backer" }}
-<p><strong>Backers</strong><br/>{{ range . }}<a href="{{ .Website }}">{{ .Name }}</a> &nbsp;{{ end }}</p>
+<p><strong>Backers</strong>{{ range . }}<a href="{{ .Website }}">{{ .Name }}</a> &nbsp;{{ end }}</p>
 {{- end }}
 </div>
 {{- else }}

--- a/sponsors.yml
+++ b/sponsors.yml
@@ -1,0 +1,19 @@
+# Config for @goreleaser/sponsors (used by .github/workflows/sponsors.yml).
+# Reads the same GitHub Sponsors / Open Collective data as the main repo and
+# renders it into src/sponsors.md between the sponsors markers.
+github_user: node-cron
+opencollective_slug: node-cron
+
+tiers:
+  - id: gold
+    name: Gold
+    monthly_rate: 50
+  - id: silver
+    name: Silver
+    monthly_rate: 25
+  - id: bronze
+    name: Bronze
+    monthly_rate: 10
+  - id: backer
+    name: Backer
+    monthly_rate: 5

--- a/src/sponsors.md
+++ b/src/sponsors.md
@@ -125,11 +125,11 @@ If it is part of your stack, sponsoring is a simple way to help keep it that way
 
 ## Our sponsors
 
-<!-- sponsors -->
+<!-- sponsors:begin -->
 <div class="sp-showcase">
   node-cron doesn't have sponsors yet. Yours could be the first logo here.
 </div>
-<!-- sponsors -->
+<!-- sponsors:end -->
 
 ## Tiers
 

--- a/src/sponsors.md
+++ b/src/sponsors.md
@@ -78,6 +78,28 @@ aside: false
   border: 1px solid var(--vp-c-brand-1);
 }
 .sp-btn.ghost:hover { background: var(--vp-c-brand-soft); }
+.sp-panel {
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  padding: 30px 24px;
+  margin: 22px 0;
+  text-align: center;
+}
+.sp-list p { margin: 28px 0; }
+.sp-list p:first-child { margin-top: 0; }
+.sp-list p:last-child { margin-bottom: 0; }
+.sp-list strong {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--vp-c-text-2);
+  margin-bottom: 6px;
+}
+.sp-list img { border-radius: 10px; margin: 8px; vertical-align: middle; transition: transform .15s ease; }
+.sp-list a:hover img { transform: translateY(-3px); }
+.sp-panel .sp-showcase { border: none; margin: 0; padding: 6px; font-size: 15px; }
 </style>
 
 # Help keep node-cron dependable.
@@ -102,6 +124,16 @@ If it is part of your stack, sponsoring is a simple way to help keep it that way
   <div class="sp-stat"><div class="num">0</div><div class="lbl">runtime<br>dependencies</div></div>
 </div>
 
+## Our sponsors
+
+<div class="sp-panel">
+<!-- sponsors:begin -->
+<div class="sp-showcase">
+  node-cron doesn't have sponsors yet. Yours could be the first logo here.
+</div>
+<!-- sponsors:end -->
+</div>
+
 ## What your sponsorship funds
 
 <div class="sp-funds">
@@ -122,14 +154,6 @@ If it is part of your stack, sponsoring is a simple way to help keep it that way
     <p>Move a CPU-bound or long-running job into an isolated forked process with a single line, and it never blocks your main event loop, while keeping the same lifecycle and events across the process boundary.</p>
   </div>
 </div>
-
-## Our sponsors
-
-<!-- sponsors:begin -->
-<div class="sp-showcase">
-  node-cron doesn't have sponsors yet. Yours could be the first logo here.
-</div>
-<!-- sponsors:end -->
 
 ## Tiers
 

--- a/src/sponsors.md
+++ b/src/sponsors.md
@@ -1,0 +1,154 @@
+---
+title: Sponsors
+description: node-cron has run in production since 2016, now in 220,000+ repositories with zero dependencies. If it helps your team, you can help keep it going.
+aside: false
+---
+
+<style scoped>
+.sp-badges { margin: 18px 0 8px; }
+.sp-badges img { display: inline; margin: 2px 3px; vertical-align: middle; }
+.sp-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 14px;
+  margin: 28px 0;
+}
+.sp-stat {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 18px;
+  text-align: center;
+}
+.sp-stat .num { font-size: 26px; font-weight: 800; letter-spacing: -0.02em; line-height: 1.15; }
+.sp-stat .num .brand { color: var(--vp-c-brand-1); }
+.sp-stat .lbl { font-size: 13px; color: var(--vp-c-text-2); margin-top: 4px; }
+.sp-funds {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin: 20px 0;
+}
+.sp-funds .sp-card {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 20px;
+}
+.sp-funds .sp-card strong { display: block; margin-bottom: 6px; }
+.sp-funds .sp-card p { margin: 0; color: var(--vp-c-text-2); font-size: 14px; }
+.sp-showcase {
+  border: 1px dashed var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 28px;
+  text-align: center;
+  color: var(--vp-c-text-2);
+  margin: 16px 0;
+}
+.sp-ctabar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 22px 24px;
+  margin: 28px 0 8px;
+}
+.sp-ctabar .copy { flex: 1; min-width: 240px; }
+.sp-ctabar .copy p { margin: 0 0 4px; }
+.sp-ctabar .copy .sub { color: var(--vp-c-text-2); font-size: 14px; margin: 0; }
+.sp-btn {
+  display: inline-block;
+  background: var(--vp-c-brand-1);
+  color: #fff !important;
+  font-weight: 700;
+  text-decoration: none !important;
+  padding: 12px 22px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+.sp-btn:hover { background: var(--vp-c-brand-2); }
+.sp-btns { display: flex; flex-wrap: wrap; gap: 10px; }
+.sp-btn.ghost {
+  background: transparent;
+  color: var(--vp-c-brand-1) !important;
+  border: 1px solid var(--vp-c-brand-1);
+}
+.sp-btn.ghost:hover { background: var(--vp-c-brand-soft); }
+</style>
+
+# Help keep node-cron dependable.
+
+node-cron has scheduled jobs in Node.js since 2016. Today it runs in 220,000+ repositories at around 20 million downloads a month, with zero runtime dependencies. It is maintained in the open, for free.
+
+If it is part of your stack, sponsoring is a simple way to help keep it that way. Your support goes to the DST and timezone test suite that keeps jobs firing correctly through clock changes, the lifecycle observability that makes production debugging easier, and the ongoing work of holding the dependency count at zero.
+
+<div class="sp-badges">
+
+[![npm downloads](https://img.shields.io/npm/dm/node-cron?label=downloads%2Fmonth&color=2f9d5f)](https://www.npmjs.com/package/node-cron)
+[![used by](https://img.shields.io/badge/used%20by-220k%2B%20repos-2f9d5f)](https://github.com/node-cron/node-cron/network/dependents)
+[![GitHub stars](https://img.shields.io/github/stars/node-cron/node-cron?color=2f9d5f)](https://github.com/node-cron/node-cron)
+[![dependencies](https://img.shields.io/badge/dependencies-0-2f9d5f)](https://www.npmjs.com/package/node-cron?activeTab=dependencies)
+
+</div>
+
+<div class="sp-stats">
+  <div class="sp-stat"><div class="num">2016</div><div class="lbl">in production since<br>(~10 years)</div></div>
+  <div class="sp-stat"><div class="num">20M+</div><div class="lbl">downloads / month<br>(npm)</div></div>
+  <div class="sp-stat"><div class="num">220k+</div><div class="lbl">repositories use it<br>(GitHub “Used by”)</div></div>
+  <div class="sp-stat"><div class="num">0</div><div class="lbl">runtime<br>dependencies</div></div>
+</div>
+
+## What your sponsorship funds
+
+<div class="sp-funds">
+  <div class="sp-card">
+    <strong>Correct scheduling through DST and timezones.</strong>
+    <p>A <code>0 3 * * *</code> job fires once at 3am local, every day, including the two days a year the clock jumps. node-cron never fires twice for the same instant, never fires into a spring-forward gap, and handles 30-minute DST zones, not just the US case. Keeping those guarantees verified against changing timezone data is constant work.</p>
+  </div>
+  <div class="sp-card">
+    <strong>One run across your whole fleet.</strong>
+    <p>Scale to four pods and a naive cron runs your nightly backup four times. <code>distributed: true</code> fires the job on exactly one instance per scheduled time, with a zero-dependency default or a Redis coordinator for high availability, and it fails loudly on deploy rather than silently at 3am.</p>
+  </div>
+  <div class="sp-card">
+    <strong>You find out when a job breaks.</strong>
+    <p>Ten lifecycle events (started, finished, failed, missed, overlap, skipped) mean you are never guessing whether last night's job ran. Runs missed to blocking I/O or a busy event loop are detected and surfaced, not swallowed.</p>
+  </div>
+  <div class="sp-card">
+    <strong>Heavy jobs that don't freeze your app.</strong>
+    <p>Move a CPU-bound or long-running job into an isolated forked process with a single line, and it never blocks your main event loop, while keeping the same lifecycle and events across the process boundary.</p>
+  </div>
+</div>
+
+## Our sponsors
+
+<!-- sponsors -->
+<div class="sp-showcase">
+  node-cron doesn't have sponsors yet. Yours could be the first logo here.
+</div>
+<!-- sponsors -->
+
+## Tiers
+
+| Tier | Monthly | What you get |
+| --- | --- | --- |
+| **Gold** | $50 | Large logo at the top of the README, docs, and this page. Visible to developers across 220,000+ dependent repositories. The most visible way to support the project. |
+| **Silver** | $25 | Logo in the README and on this page, seen by developers in the 220,000+ repositories that already depend on node-cron. |
+| **Bronze** | $10 | Your logo and link on this page. A meaningful presence that helps keep the library tested and at zero dependencies. |
+| **Backer** | $5 | Your name and link in the backers list. Every bit adds up to the hours that keep the library tested and at zero dependencies. |
+
+<div class="sp-ctabar">
+  <div class="copy">
+    <p><strong>Does node-cron help your team?</strong> Sponsoring helps keep it maintained, tested, and dependency-free for the years ahead. Every tier makes a difference.</p>
+    <p class="sub">Companies and individuals are equally welcome, from $5 a month.</p>
+  </div>
+  <span class="sp-btns">
+    <a class="sp-btn" href="https://github.com/sponsors/node-cron">GitHub Sponsors →</a>
+    <a class="sp-btn ghost" href="https://opencollective.com/node-cron">Open Collective →</a>
+  </span>
+</div>
+
+Sponsor through [GitHub Sponsors](https://github.com/sponsors/node-cron) or [Open Collective](https://opencollective.com/node-cron). This page updates automatically from both.


### PR DESCRIPTION
## What

Adds a `/sponsors` page and the automation to keep it current.

- **`/sponsors` page** (`src/sponsors.md`): the project's trust signals (220k+ repos, 20M downloads/month, in production since 2016, zero dependencies), what sponsorship funds, the tiers, and sponsor links via GitHub Sponsors and Open Collective. Linked from the nav.
- **Automation** mirroring the main repo: `sponsors.yml` (tiers), `sponsors.tpl.md` (render template), and `.github/workflows/sponsors.yml` to refresh the page daily and on demand via [@goreleaser/sponsors](https://github.com/goreleaser/sponsors), opening a PR when the list changes.
- The sponsor block ships empty (`<!-- sponsors:begin/end -->`); the workflow populates it.

## Requires

A `SPONSORS_TOKEN` secret (PAT with read access to the org's sponsors) for the workflow's `generate` step. Already configured.